### PR TITLE
feature: Minimal map size

### DIFF
--- a/ed_navigation/src/navigation_plugin.cpp
+++ b/ed_navigation/src/navigation_plugin.cpp
@@ -29,7 +29,7 @@ void constructConstraint(const ed::ConvexHull& chull, std::stringstream& constra
 {
     if (chull.points.size() < 3)
     {
-        std::cout << "Error: Convex hull has to consist of at least three points !!" << std::endl;
+        ROS_ERROR("Convex hull has to consist of at least three points !!");
         return;
     }
 

--- a/ed_navigation/src/navigation_plugin.cpp
+++ b/ed_navigation/src/navigation_plugin.cpp
@@ -176,7 +176,7 @@ void NavigationPlugin::initialize()
 
 // ----------------------------------------------------------------------------------------------------
 
-void NavigationPlugin::process(const ed::WorldModel& world, ed::UpdateRequest& req)
+void NavigationPlugin::process(const ed::WorldModel& world, ed::UpdateRequest& /*req*/)
 {
     // Check for services
     world_ = &world;

--- a/ed_navigation/src/navigation_plugin.cpp
+++ b/ed_navigation/src/navigation_plugin.cpp
@@ -162,20 +162,7 @@ void NavigationPlugin::configure(tue::Configuration config)
     // Configure the occupancy grid publisher
     if (config.readGroup("occupancy_grid_publisher"))
     {
-        double res, min_z, max_z, unknown_obstacle_inflation;
-        std::string frame_id;
-        config.value("frame_id", frame_id);
-        config.value("resolution", res);
-
-        config.value("min_z", min_z);
-        config.value("max_z", max_z);
-
-        if (!config.value("unknown_obstacle_inflation", unknown_obstacle_inflation, tue::config::OPTIONAL))
-            unknown_obstacle_inflation = 0.0;
-
-        ROS_DEBUG_STREAM("[ED NAVIGATION] Using min_z: " << min_z << ",  max_z: " << max_z);
-        occupancy_grid_publisher_.configure(nh, res, min_z, max_z, frame_id, unknown_obstacle_inflation);
-
+        occupancy_grid_publisher_.configure(nh, config);
         config.endGroup();
     }
 }

--- a/ed_navigation/src/occupancy_grid_publisher.cpp
+++ b/ed_navigation/src/occupancy_grid_publisher.cpp
@@ -94,27 +94,6 @@ bool OccupancyGridPublisher::getMapData(const ed::WorldModel& world, std::vector
                 }
             }
         }
-//        else if (convex_hull_enabled_)
-//        {
-//            if (e->convexHull().z_max + e->pose().t.z > min_z_)  // Filter the ground
-//            {
-
-//                const std::vector<geo::Vec2f>& chull_points = e->convexHull().points;
-//                for(std::vector<geo::Vec2f>::const_iterator it = chull_points.begin(); it != chull_points.end(); ++it)
-//                {
-//                    float x = it->x + e->pose().t.x;
-//                    float y = it->y + e->pose().t.y;
-
-//                    min.x = std::min<double>(x - unknown_obstacle_inflation_, min.x);
-//                    max.x = std::max<double>(x + unknown_obstacle_inflation_, max.x);
-
-//                    min.y = std::min<double>(y - unknown_obstacle_inflation_, min.y);
-//                    max.y = std::max<double>(y + unknown_obstacle_inflation_, max.y);
-
-//                    is_empty = false;
-//                }
-//            }
-//        }
     }
 
     // Bounds fix
@@ -164,26 +143,6 @@ void OccupancyGridPublisher::updateMap(const ed::EntityConstPtr& e, Map& map)
 
         }
     }
-//    else if (convex_hull_enabled_) // Do convex hull
-//    {
-//        if (e->convexHull().z_max + e->pose().t.z > min_z_ && e->convexHull().z_min + e->pose().t.z < max_z_)
-//        {
-//            const std::vector<geo::Vec2f>& chull_points = e->convexHull().points;
-//
-//            for (unsigned int i = 0; i < chull_points.size(); ++i)
-//            {
-//                int j = (i + 1) % chull_points.size();
-//
-//                geo::Vector3 p1w(chull_points[i].x + e->pose().t.x, chull_points[i].y + e->pose().t.y, 0);
-//                geo::Vector3 p2w(chull_points[j].x + e->pose().t.x, chull_points[j].y + e->pose().t.y, 0);
-//
-//                // Check if all points are on the map
-//                cv::Point2i p1, p2;
-//                if (map.worldToMap(p1w.x, p1w.y, p1.x, p1.y) && map.worldToMap(p2w.x, p2w.y, p2.x, p2.y) )
-//                    cv::line(map.image, p1, p2, value, unknown_obstacle_inflation_ / map.resolution() + 1);
-//            }
-//        }
-//    }
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/ed_navigation/src/occupancy_grid_publisher.cpp
+++ b/ed_navigation/src/occupancy_grid_publisher.cpp
@@ -47,12 +47,12 @@ void OccupancyGridPublisher::publish(const ed::WorldModel& world)
     }
     else
     {
-//        std::cout << "Error getting map data:" << std::endl;
-//        std::cout << "width: " << width_ << std::endl;
-//        std::cout << "height: " << height_ << std::endl;
-//        std::cout << "resolution: " << res_ << std::endl;
-//        std::cout << "min_z: " << min_z_ << std::endl;
-//        std::cout << "max_z: " << max_z_ << std::endl;
+        ROS_DEBUG_STREAM("Error getting map data:" << std::endl
+                         << "width: " << map_.width_in_cells() << std::endl
+                         << "height: " << map_.height_in_cells() << std::endl
+                         << "resolution: " << map_.resolution() << std::endl
+                         << "min_z: " << min_z_ << std::endl
+                         << "max_z: " << max_z_);
     }
 }
 

--- a/ed_navigation/src/occupancy_grid_publisher.h
+++ b/ed_navigation/src/occupancy_grid_publisher.h
@@ -20,6 +20,19 @@ public:
 
     OccupancyGridPublisher() : configured_(false) {}
 
+    /**
+     * @brief configure configure hook
+     * @param nh NodeHandle to use
+     * @param config Configuration object with the following parameters:
+     * parametergroup: occupancy_grid_publisher
+     * parameters:
+     *      frame_id (recommended: map): Frame id of the published costmap
+     *      resolution (recommended: 0.05): Resolution of the published costmap
+     *      min_z (recommended: 0.025): Only shaped above this height are taken into account
+     *      max_z (recommended: 1.8): Only shaped above this height are taken into account
+     *      min_map_size_x (optional, default 20): Minimal map size in x-direction, any entities with a shape outside this size will enlarge the map.
+     *      min_map_size_y (optional, default 20): Minimal map size in y-direction, any entities with a shape outside this size will enlarge the map.
+     */
     void configure(ros::NodeHandle& nh, tue::Configuration config);
 
     void publish(const ed::WorldModel& world);

--- a/ed_navigation/src/occupancy_grid_publisher.h
+++ b/ed_navigation/src/occupancy_grid_publisher.h
@@ -1,10 +1,15 @@
 #ifndef occupancy_grid_publisher_h_
 #define occupancy_grid_publisher_h_
 
-#include <ros/ros.h>
-#include <geolib/datatypes.h>
 #include <ed/plugin.h>
 #include <ed/types.h>
+
+#include <geolib/datatypes.h>
+
+#include <ros/node_handle.h>
+#include <ros/publisher.h>
+
+#include <tue/config/configuration.h>
 
 #include "map.h"
 
@@ -15,8 +20,7 @@ public:
 
     OccupancyGridPublisher() : configured_(false) {}
 
-    void configure(ros::NodeHandle& nh, const double &res, const double& min_z, const double& max_z,
-                   const std::string &frame_id, double unknown_obstacle_inflation);
+    void configure(ros::NodeHandle& nh, tue::Configuration config);
 
     void publish(const ed::WorldModel& world);
 
@@ -40,10 +44,7 @@ private:
 
     double min_z_, max_z_;
 
-    // Inflation of unknown obstacles (in meters)
-    double unknown_obstacle_inflation_;
-
-    bool convex_hull_enabled_;
+    double min_map_size_x_, min_map_size_y_;
 
     // Map
     Map map_;


### PR DESCRIPTION
This PR adds the option change the minimal map size of the published navigation costmap. Previously this was a fixed value, this PR makes it configurable. This prevents any planner issue when the robot reached a position outside the costmap.

Without adding the new parameters in the config, the old behaviour is used.

The `unknown_obstacle_inflation` option is removed as its implementation has been commented out for a long time.